### PR TITLE
Make getOffset usable for SVG elements

### DIFF
--- a/src/rect.js
+++ b/src/rect.js
@@ -32,17 +32,19 @@ const getOffset = el => {
     const br = el.getBoundingClientRect();
     return {
         x: br.left + win.pageXOffset,
-        y: br.top + win.pageYOffset
+        y: br.top + win.pageYOffset,
+        width: br.width,
+        height: br.height
     };
 };
 
 Rect.ofElement = el => {
-    const {x, y} = getOffset(el);
+    const {x, y, width, height} = getOffset(el);
     return Rect(
         x,
         y,
-        el.offsetWidth,
-        el.offsetHeight
+        width,
+        height
     );
 };
 


### PR DESCRIPTION
Hi Lars,

Pagemap didn't work in my use case with SVG <rect> tags, so
I patched Rect.getOffset to return the width and height of the bounding box,
and use it in Rect.ofElement instead of the offset{Width,Height} of el.

I sadly don't have any time to make proper testing but I hope this little change might enable SVG support in Pagemap.

Thanks for your work and your sharing !